### PR TITLE
Stub remotingCLI symbol and replace outdated CasC file content when still present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.42</version>
+        <version>3.43</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <revision>1.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- Using always very recent on purpose -->
-        <jenkins.version>2.161</jenkins.version>
+        <jenkins.version>2.165</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Evergreen Plugin</name>

--- a/src/main/java/io/jenkins/plugins/evergreen/EvergreenCascUpdater.java
+++ b/src/main/java/io/jenkins/plugins/evergreen/EvergreenCascUpdater.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.evergreen;
+
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This class is mostly a workaround to update config-as-code (JCasC) files on the disk.
+ * <p>
+ * E.g. since https://github.com/jenkinsci/jenkins/pull/3838, i.e. Jenkins 2.165, the remoting CLI has been removed from Jenkins Core.
+ * This means that in JCasC, an attempt to configure it will simply fail, crashing the instance during startup.
+ * <p>
+ * In Evergreen, we don't a way to update the evergreen-client, or static files, yet. But we can update plugins.
+ * So using the Evergreen Jenkins plugin, we detect these outdated files, and update them in place, so next update will not just crash
+ * instances.
+ */
+@Extension
+public class EvergreenCascUpdater {
+
+    private static final Logger LOGGER = Logger.getLogger(EvergreenCascUpdater.class.getName());
+    private static final String SHA1_BEFORE_CHANGE = "8d4ef50d006e24d26c4eaf0a9122a2dfc4f40dd9";
+
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
+    public static void init() throws Exception {
+        final Path createAdminUserFilePath = Paths.get(System.getenv("CASC_JENKINS_CONFIG"), "create-admin-user.yaml");
+        fixFileIfNeeded(createAdminUserFilePath);
+    }
+
+    @VisibleForTesting
+    static void fixFileIfNeeded(Path createAdminUserFilePath) throws IOException {
+        if (createAdminUserFilePath.toFile().exists()) {
+            byte[] fileContent = Files.readAllBytes(createAdminUserFilePath);
+            String fileSha1 = DigestUtils.sha1Hex(fileContent);
+
+            if (SHA1_BEFORE_CHANGE.equals(fileSha1)) {
+                LOGGER.log(Level.WARNING, "Outdated config file detected, updating it with new version");
+                Files.copy(EvergreenCascUpdater.class.getResourceAsStream(
+                        "/io/jenkins/plugins/evergreen/create-admin-user-without-remotingCLI.yaml"),
+                           createAdminUserFilePath,
+                           StandardCopyOption.REPLACE_EXISTING);
+            }
+        } else {
+            LOGGER.log(Level.WARNING, "JCasC file not found, something is very very wrong");
+        }
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/evergreen/EvergreenCascUpdater.java
+++ b/src/main/java/io/jenkins/plugins/evergreen/EvergreenCascUpdater.java
@@ -5,7 +5,12 @@ import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.init.InitMilestone;
 import hudson.init.Initializer;
+import hudson.model.PersistentDescriptor;
+import jenkins.model.GlobalConfiguration;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -55,4 +60,8 @@ public class EvergreenCascUpdater {
         }
     }
 
+    @Extension @Symbol("remotingCLI")
+    @Restricted(NoExternalUse.class)
+    public static class RemotingCLIEvergreenStub extends GlobalConfiguration implements PersistentDescriptor {
+    }
 }

--- a/src/main/java/io/jenkins/plugins/evergreen/RemotingCLIEvergreenStub.java
+++ b/src/main/java/io/jenkins/plugins/evergreen/RemotingCLIEvergreenStub.java
@@ -30,10 +30,11 @@ import java.util.logging.Logger;
  * So using the Evergreen Jenkins plugin, we detect these outdated files, and update them in place, so next update will not just crash
  * instances.
  */
-@Extension
-public class EvergreenCascUpdater {
+@Extension @Symbol("remotingCLI")
+@Restricted(NoExternalUse.class)
+public class RemotingCLIEvergreenStub extends GlobalConfiguration implements PersistentDescriptor {
 
-    private static final Logger LOGGER = Logger.getLogger(EvergreenCascUpdater.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(RemotingCLIEvergreenStub.class.getName());
     private static final String SHA1_BEFORE_CHANGE = "8d4ef50d006e24d26c4eaf0a9122a2dfc4f40dd9";
 
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED, before = InitMilestone.JOB_LOADED)
@@ -50,7 +51,7 @@ public class EvergreenCascUpdater {
 
             if (SHA1_BEFORE_CHANGE.equals(fileSha1)) {
                 LOGGER.log(Level.WARNING, "Outdated config file detected, updating it with new version");
-                Files.copy(EvergreenCascUpdater.class.getResourceAsStream(
+                Files.copy(RemotingCLIEvergreenStub.class.getResourceAsStream(
                         "/io/jenkins/plugins/evergreen/create-admin-user-without-remotingCLI.yaml"),
                            createAdminUserFilePath,
                            StandardCopyOption.REPLACE_EXISTING);
@@ -60,8 +61,4 @@ public class EvergreenCascUpdater {
         }
     }
 
-    @Extension @Symbol("remotingCLI")
-    @Restricted(NoExternalUse.class)
-    public static class RemotingCLIEvergreenStub extends GlobalConfiguration implements PersistentDescriptor {
-    }
 }

--- a/src/main/resources/io/jenkins/plugins/evergreen/create-admin-user-without-remotingCLI.yaml
+++ b/src/main/resources/io/jenkins/plugins/evergreen/create-admin-user-without-remotingCLI.yaml
@@ -1,0 +1,18 @@
+jenkins:
+  # Agent to master security
+  remotingSecurity:
+    enabled: true
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: ${JENKINS_ADMIN_PASSWORD}
+  authorizationStrategy:
+    loggedInUsersCanDoAnything:
+      allowAnonymousRead: false
+
+  #CSRF issuer
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false

--- a/src/test/java/io/jenkins/plugins/evergreen/EvergreenCascUpdaterTest.java
+++ b/src/test/java/io/jenkins/plugins/evergreen/EvergreenCascUpdaterTest.java
@@ -30,7 +30,7 @@ public class EvergreenCascUpdaterTest {
                    StandardCopyOption.REPLACE_EXISTING);
 
         // When
-        EvergreenCascUpdater.fixFileIfNeeded(filePath);
+        RemotingCLIEvergreenStub.fixFileIfNeeded(filePath);
 
         // Then
         final byte[] data = Files.readAllBytes(filePath);

--- a/src/test/java/io/jenkins/plugins/evergreen/EvergreenCascUpdaterTest.java
+++ b/src/test/java/io/jenkins/plugins/evergreen/EvergreenCascUpdaterTest.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.evergreen;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.hamcrest.core.IsEqual;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class EvergreenCascUpdaterTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void fixFileIfNeeded() throws IOException {
+        // given
+        final File file = folder.newFile();
+        final Path filePath = file.toPath();
+        Files.copy(EvergreenCascUpdaterTest.class.getResourceAsStream("/io/jenkins/plugins/evergreen/create-admin-user-to-replace.yaml"),
+                   filePath,
+                   StandardCopyOption.REPLACE_EXISTING);
+
+        // When
+        EvergreenCascUpdater.fixFileIfNeeded(filePath);
+
+        // Then
+        final byte[] data = Files.readAllBytes(filePath);
+        assertThat(DigestUtils.sha1Hex(data), equalTo("7cae6193a5d4e837ffdc54fb96361a332b99df3c"));
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/evergreen/create-admin-user-to-replace.yaml
+++ b/src/test/resources/io/jenkins/plugins/evergreen/create-admin-user-to-replace.yaml
@@ -1,0 +1,21 @@
+jenkins:
+  # Agent to master security
+  remotingSecurity:
+    enabled: true
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: "admin"
+          password: ${JENKINS_ADMIN_PASSWORD}
+  authorizationStrategy:
+    loggedInUsersCanDoAnything:
+      allowAnonymousRead: false
+
+  #CSRF issuer
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false
+security:
+  remotingCLI:
+    enabled: false


### PR DESCRIPTION
Still WIP, because I need to test it thoroughly, manually too, for obvious reasons, but I believe the current code _should_ do it.

Should allow us in a near future, once deployed, to go through some updated version of https://github.com/jenkins-infra/evergreen/pull/404

@rtyler 